### PR TITLE
Identify orphaned SAS Work directories

### DIFF
--- a/worktop
+++ b/worktop
@@ -435,6 +435,8 @@ function calculate {
         thisPid=$(( 16#${thisHex} )) 
         # check meta user lookup hash
         var=lookuphash__${thisHost/-/}_${thisPid}
+        # swap the _ back to . for FQDN hosts for display purposes
+        thisHost=$(echo "${thisHost}" | tr _ .)        
 	if [ -n "${!var}" ] ; then
 	  thisUser="${!var}"
         else 

--- a/worktop
+++ b/worktop
@@ -118,7 +118,7 @@ checkEverything() {
 
   # commands to check for 
   requiredThings=("tput" "date" "man" "getopts" "basename" "hostname" 
-    "date" "du" "sort" "find" "basename" "cut" "xargs" "read" "echo")
+    "date" "du" "sort" "find" "basename" "cut" "xargs" "read" "echo" "tr")
   
   # check that the arguments we have are correct and stuff
   while getopts ":d:n:l:i:g:hs" option; do
@@ -397,11 +397,12 @@ function calculate {
            ((++i))
         done < $metafile
         fileshort=$(basename $metafile)
-        nodename=${fileshort:9:99}
-	for (( CNTR=0; CNTR<${#raw[@]} ; CNTR+=1 )); do
-          line=${raw[$CNTR]}
+        nodename=$(echo ${fileshort:9:99} |  tr . _ )
+	      for (( CNTR=0; CNTR<${#raw[@]} ; CNTR+=1 )); do
+          # strip new line character from the string as we assign to $line
+          line=${raw[$CNTR]%'\n'}
           thisPid=${line% *}
-          thisuser=${line#* }
+          thisuser=${line#$thisPid }
           # removes - from hostname otherwise the variable assigment fails
           declare lookuphash__${nodename/-/}_${thisPid}="${thisuser}"
         done
@@ -429,7 +430,8 @@ function calculate {
       local dirsub="${thisDir:0:8}"
       if [[ "${dirsub}" == "SAS_work" || "${dirsub}" == "SAS_util" ]] ; then 
         thisHex=$(echo "${thisDir}" | cut -d "_" -f 2 | cut -b 10-)
-        thisHost=$(echo "${thisDir}" | cut -d "_" -f 3)  
+        # swap the _ back to . for FQDN hosts
+        thisHost=$(echo "${thisDir}" | cut -d "_" -f 3 | tr . _ )  
         thisPid=$(( 16#${thisHex} )) 
         # check meta user lookup hash
         var=lookuphash__${thisHost/-/}_${thisPid}

--- a/worktop
+++ b/worktop
@@ -389,7 +389,6 @@ function calculate {
     printstatus "calculating" "${BgYel}"
 
     # load any metaindexes that may exist
-    unset lookuphash
     if [ $(find $METAFILEDIR/workmeta* 2>/dev/null | wc -l) -gt 0 ]; then 
       for metafile in $METAFILEDIR/workmeta*; do
         let i=0

--- a/worktop
+++ b/worktop
@@ -54,6 +54,10 @@ RCol=$(tput sgr0)
 CLine=$(tput el)
 CDim=$(tput dim)
 Bce=$(tput bce)
+URed=$(tput smul)$(tput setaf 1)
+UGre=$(tput smul)$(tput setaf 2)
+UYel=$(tput smul)$(tput setaf 3)
+UWhi=$(tput smul)$(tput setaf 7)
 
 
 #---  FUNCTIONS  ---------------------------------------------------------------
@@ -369,8 +373,8 @@ function calculate {
   # keep doing this for ever and ever
   while true ; do
     # variable cleardown and reinit
-    unset rowShade col1vals col2vals col3vals col4vals col5vals timermsg
-    declare -a rowShade col1vals col2vals col3vals col4vals col5vals
+    unset rowShade col1vals col2vals col3vals col4vals col5vals timermsg active
+    declare -a rowShade col1vals col2vals col3vals col4vals col5vals active
     timerstart=$(date +%s%3N)
     printstatus "sizing directory" "${BgRed}"
 
@@ -430,7 +434,6 @@ function calculate {
       local dirsub="${thisDir:0:8}"
       if [[ "${dirsub}" == "SAS_work" || "${dirsub}" == "SAS_util" ]] ; then 
         thisHex=$(echo "${thisDir}" | cut -d "_" -f 2 | cut -b 10-)
-        # swap the _ back to . for FQDN hosts
         thisHost=$(echo "${thisDir}" | cut -d "_" -f 3 | tr . _ )  
         thisPid=$(( 16#${thisHex} )) 
         # check meta user lookup hash
@@ -446,13 +449,28 @@ function calculate {
         thisPid="-"
         thisUser="-"
       fi
+
+      #check if the pid is active. 0 = alive on host
+      ps -p $thisPid 2>&1 >/dev/null
+      active=$?
+
       # apply highlighting
-      if [[ ${thisSize} -ge $WORKLIMIT ]] ; then
-        rowShade[$CNTR]="${Red}"
-      elif [[ ${thisSize} -ge $NOTQUITELIMIT ]] ; then
-        rowShade[$CNTR]="${Yel}"
+      if [[ $active == 0 ]]; then
+        if [[ ${thisSize} -ge $WORKLIMIT ]] ; then
+          rowShade[$CNTR]="${Red}"
+        elif [[ ${thisSize} -ge $NOTQUITELIMIT ]] ; then
+          rowShade[$CNTR]="${Yel}"
+        else
+          rowShade[$CNTR]="${RCol}"
+        fi
       else
-        rowShade[$CNTR]="${RCol}"
+        if [[ ${thisSize} -ge $WORKLIMIT ]] ; then
+          rowShade[$CNTR]="${URed}"
+        elif [[ ${thisSize} -ge $NOTQUITELIMIT ]] ; then
+          rowShade[$CNTR]="${UYel}"
+        else
+          rowShade[$CNTR]="${UWhi}"
+        fi
       fi
 
       col1vals[$CNTR]="$(tput cup ${thisrow} ${col1pos})${thisPrettySize:0:${col1len}}"


### PR DESCRIPTION
This is an implementation option for #3  identifying local orphan word directories. For each PID that we identify, we check whether or not that PID is active, if it isn't then we show that work directory as underlined. The other conditional formatting remains the same:

![image](https://user-images.githubusercontent.com/1965454/74757620-a35d1500-524c-11ea-8e16-e6800fed6d31.png)

We probably also need to do a check whether or not we do this just for local node sessions. Its potentially misleading as it is in a multi node environment. Works very nicely for single machine deployments though.